### PR TITLE
Make softsense module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,72 @@
+version: 2.1
+
+orbs:
+  ci: softsense/ci-tools@0.1.42
+
+jobs:
+  test:
+    docker:
+      - image: circleci/golang:1.12 # Primary container image where all steps run.
+        environment:
+          TZ: UTC
+    environment:
+      # Test result directory. go-short is the name of the test result
+      TEST_RESULTS: /tmp/test-results/go-short
+    steps:
+      - checkout
+      - run:
+          name: Running unit tests
+          command: |
+            # Prepare CircleCI test summary https://circleci.com/docs/2.0/collect-test-data/
+            mkdir -p ${TEST_RESULTS}
+            go get github.com/jstemmer/go-junit-report # The reporter used to format tests for CircleCI
+
+            # Run tests and export results
+            trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT # Format tests
+            make test | tee ${TEST_RESULTS}/go-test.out
+      - store_test_results: # Upload test results for display in Test Summary
+          path: /tmp/test-results
+
+# Most likely you can keep the workflows as is
+workflows:
+  version: 2
+  branch:
+    jobs:
+      - test:
+          context: softsense
+          filters:
+            branches:
+              ignore:
+                - master
+            tags:
+              ignore:
+                - /^.*/
+
+  master:
+    jobs:
+      - test:
+          context: softsense
+          filters:
+            branches:
+              only:
+                - master
+
+      - ci/create_version:
+          name: create_release_version
+          snapshot: false
+          prefix: "v"
+          context: softsense
+          requires:
+            - test
+
+      - ci/release:
+          name: release
+          github_release: true
+          draft: true
+          context: softsense
+          requires:
+            - create_release_version
+          filters:
+            branches:
+              only:
+                - master

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Go implementation of the package url spec
 
-[![Build Status](https://travis-ci.com/package-url/packageurl-go.svg)](https://travis-ci.com/package-url/packageurl-go)
+[![Build Status](https://circleci.com/gh/softsense/packageurl-go.svg)](https://circleci.com/gh/softsense/packageurl-go)
 
 
 ## Install
 ```
-go get -u github.com/package-url/packageurl-go
+go get -u github.com/softsense/packageurl-go
 ```
 
 ## Versioning
@@ -24,7 +24,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/package-url/packageurl-go"
+	"github.com/softsense/packageurl-go"
 )
 
 func main() {
@@ -40,7 +40,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/package-url/packageurl-go"
+	"github.com/softsense/packageurl-go"
 )
 
 func main() {
@@ -70,5 +70,5 @@ go test -v -cover ./...
 --- PASS: TestToStringExamples (0.00s)
 PASS
 coverage: 94.7% of statements
-ok      github.com/package-url/packageurl-go    0.002s
+ok      github.com/softsense/packageurl-go    0.002s
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/package-url/packageurl-go
+module github.com/softsense/packageurl-go
 
 go 1.12

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/package-url/packageurl-go"
+	"github.com/softsense/packageurl-go"
 )
 
 type TestFixture struct {


### PR DESCRIPTION
Renames the module to match the organization of the fork. Adds CircleCI configuration and replaces TravisCI references.