### PR TITLE
Remove version type adjustments

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -267,6 +267,8 @@ func FromString(purl string) (PackageURL, error) {
 		remainder = remainder[:index]
 	}
 
+	// start out by extracting the purl version (if one is specified) to
+	// prevent it from being type-adjusted (might change casing, for example)
 	atIndex := strings.Index(remainder, "@")
 	version := ""
 	if atIndex != -1 {

--- a/packageurl.go
+++ b/packageurl.go
@@ -267,6 +267,17 @@ func FromString(purl string) (PackageURL, error) {
 		remainder = remainder[:index]
 	}
 
+	atIndex := strings.Index(remainder, "@")
+	version := ""
+	if atIndex != -1 {
+		v, err := url.PathUnescape(remainder[atIndex+1:])
+		if err != nil {
+			return PackageURL{}, fmt.Errorf("failed to unescape purl version: %s", err)
+		}
+		version = v
+		remainder = remainder[:atIndex]
+	}
+
 	nextSplit := strings.SplitN(remainder, ":", 2)
 	if len(nextSplit) != 2 || nextSplit[0] != "pkg" {
 		return PackageURL{}, errors.New("scheme is missing")
@@ -287,21 +298,12 @@ func FromString(purl string) (PackageURL, error) {
 	remainder = nextSplit[1]
 
 	index = strings.LastIndex(remainder, "/")
-	name := typeAdjustName(purlType, remainder[index+1:])
-	version := ""
-
-	atIndex := strings.Index(name, "@")
-	if atIndex != -1 {
-		v, err := url.PathUnescape(name[atIndex+1:])
-		if err != nil {
-			return PackageURL{}, fmt.Errorf("failed to unescape purl version: %s", err)
-		}
-		version = v
-		name, err = url.PathUnescape(name[:atIndex])
-		if err != nil {
-			return PackageURL{}, fmt.Errorf("failed to unescape purl name: %s", err)
-		}
+	adjusted := typeAdjustName(purlType, remainder[index+1:])
+	name, err := url.PathUnescape(adjusted)
+	if err != nil {
+		return PackageURL{}, fmt.Errorf("failed to unescape purl name: %s", err)
 	}
+
 	namespaces := []string{}
 
 	if index != -1 {

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -199,13 +199,6 @@ func TestToStringExamples(t *testing.T) {
 		if tc.IsInvalid == true {
 			continue
 		}
-		// TODO: Remove after merging https://github.com/softsense/packageurl-go/pull/2
-		// Switching the order of version parsing has the side-effect of making
-		// angular/animation@12.3.1 the version with how this is parsed, but
-		// the PR removes the ambiguity of what the version separator is.
-		if tc.CanonicalPurl == "pkg:npm/%40angular/animation@12.3.1" {
-			continue
-		}
 		instance := packageurl.NewPackageURL(
 			tc.PackageType, tc.Namespace, tc.Name,
 			tc.Version, tc.Qualifiers(), tc.Subpath)


### PR DESCRIPTION
Changes the order of component parsing parsing so that versions are not adjusted to the type, as that is only intended for names and namespaces.

For example, `pkg:github/Motion-Project/motion@Release-4.3.0` was incorrectly parsed as `pkg:github/motion-project/motion@release-4.3.0` previous to this change, which invalidated the version.